### PR TITLE
Fix type error

### DIFF
--- a/src/ais.py
+++ b/src/ais.py
@@ -6,7 +6,7 @@ from collections import namedtuple
 VesselData = namedtuple('VesselData', ['MMSI', 'LAT', 'LON', 'VesselName'])
 
 class AIS:
-    def __init__(self, logger: Logger, csv_path: str, requested_mmsis: list[str]):
+    def __init__(self, logger: Logger, csv_path: str, requested_mmsis: list[int]):
         """
         AIS class constructor
 


### PR DESCRIPTION
In the AIS class the `requested_mmsis` type is represented as a `list[str]` but in reality it's actually a `list[int]` and given Python typing isn't checked at runtime this risks masking a more serious error if someone were to modify the config to use strings instead of int's for vessel-mmsi data.

---

**Test Plan**

Two ways to test this, first run the before and after change and add a print statement or debugger logpoint that prints out the `requested_mmsis` that is passed into the AIS class. Here is a gist showing the before and after:
https://gist.github.com/sendhil/98c337ddda71426d93903dc7ab9f7a46

Also, run the app as normal and verify the output looks similar (note as I don't have access to Lattice there's a bunch of errors about being unable to connect). Here are some gists showing before/after:

- Before: https://gist.github.com/sendhil/2d556e7f4ef034253b6c8755689e5071
- After: https://gist.github.com/sendhil/d59825a47de6b2943c8b0f59202cd7ad