### PR TITLE
Utilize Pydantic to load and validate the config

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ APScheduler==3.10.4
 PyYAML==6.0.2
 pandas==2.2.3
 aiohttp~=3.10.10
+pydantic==2.9.2

--- a/src/ais.py
+++ b/src/ais.py
@@ -6,7 +6,7 @@ from collections import namedtuple
 VesselData = namedtuple('VesselData', ['MMSI', 'LAT', 'LON', 'VesselName'])
 
 class AIS:
-    def __init__(self, logger: Logger, csv_path: str, requested_mmsis: list[str]):
+    def __init__(self, logger: Logger, csv_path: str, requested_mmsis: list[int]):
         """
         AIS class constructor
 

--- a/src/main.py
+++ b/src/main.py
@@ -7,24 +7,23 @@ from datetime import timedelta
 
 import yaml
 from apscheduler.schedulers.background import BackgroundScheduler
+from pydantic import BaseModel, Field
 
+from ais import AIS
 from integration import AISLatticeIntegration
 from lattice import Lattice
-from ais import AIS
 
 DATASET_PATH = "var/ais_vessels.csv"
 
-def validate_config(cfg):
-    if "lattice-ip" not in cfg:
-        raise ValueError("missing lattice-ip")
-    if "lattice-bearer-token" not in cfg:
-        raise ValueError("missing lattice-bearer-token")
-    if "entity-update-rate-seconds" not in cfg:
-        raise ValueError("missing entity-update-rate-seconds")
-    if "vessel-mmsi" not in cfg:
-        raise ValueError("missing vessel-mmsi")
-    if "ais-generate-interval-seconds" not in cfg:
-        raise ValueError("missing ais-generate-interval-seconds")
+
+class Config(BaseModel):
+    lattice_ip: str = Field(alias="lattice-ip")
+    lattice_bearer_token: str = Field(alias="lattice-bearer-token")
+    entity_update_rate_seconds: int = Field(alias="entity-update-rate-seconds")
+    vessel_mmsi: list[int] = Field(alias="vessel-mmsi")
+    ais_generate_interval_seconds: int = Field(
+        alias="ais-generate-interval-seconds"
+    )
 
 
 if __name__ == "__main__":
@@ -33,28 +32,29 @@ if __name__ == "__main__":
     logger.setLevel(logging.DEBUG)
     logger.info("starting ais-lattice-integration")
 
-    parser = argparse.ArgumentParser(description="AIS Vessel to Lattice Mesh Integration")
+    parser = argparse.ArgumentParser(
+        description="AIS Vessel to Lattice Mesh Integration"
+    )
     parser.add_argument(
-        "--config", action="store", dest="configpath", default="../var/config.yml"
+        "--config",
+        action="store",
+        dest="configpath",
+        default="../var/config.yml",
     )
     args = parser.parse_args()
 
     logger.info(f"got config path {args.configpath}")
 
     with open(args.configpath) as config_file:
-        cfg = yaml.load(config_file, Loader=yaml.FullLoader)
-        validate_config(cfg)
+        cfg_dict = yaml.load(config_file, Loader=yaml.FullLoader)
+        cfg = Config.model_validate(cfg_dict)
 
     # range check the ais dataset generation interval
-    generate_interval = max(1, min(cfg["ais-generate-interval-seconds"], 60))
+    generate_interval = max(1, min(cfg.ais_generate_interval_seconds, 60))
 
-    ais_data = AIS(
-        logger,
-        DATASET_PATH,
-        cfg["vessel-mmsi"]
-    )
+    ais_data = AIS(logger, DATASET_PATH, cfg.vessel_mmsi)
 
-    lattice_api = Lattice(logger, cfg["lattice-ip"], cfg["lattice-bearer-token"])
+    lattice_api = Lattice(logger, cfg.lattice_ip, cfg.lattice_bearer_token)
 
     ais_lattice_integration_hook = AISLatticeIntegration(
         logger, lattice_api, ais_data
@@ -66,13 +66,17 @@ if __name__ == "__main__":
         ais_data.refresh_ais, "interval", seconds=generate_interval
     )
     scheduler.add_job(
-        lambda: run(ais_lattice_integration_hook.publish_vessels_as_entities()),
+        lambda: run(
+            ais_lattice_integration_hook.publish_vessels_as_entities()
+        ),
         "interval",
-        seconds=cfg["entity-update-rate-seconds"],
+        seconds=cfg.entity_update_rate_seconds,
     )
     scheduler.start()
 
-    logger.info("Press Ctrl+{0} to exit".format("Break" if os.name == "nt" else "C"))
+    logger.info(
+        "Press Ctrl+{0} to exit".format("Break" if os.name == "nt" else "C")
+    )
     try:
         while True:
             time.sleep(2)


### PR DESCRIPTION
The code to load the configuration is a bit brittle as there isn't typing, the values are being accessed in a dictionary with magic strings, and the validation is done by hand. 

This PR utilizes Pydantic to add typing to the config and remove boilerplate validation code.

---

**Test Plan**

I tested this by adding code to print out the config before/after, you can see it in this gist here:
https://gist.github.com/sendhil/6d09c8da3678d63235f8efb30925b300.

I also ran the sample normally and compared the output of the before and after (I don't have access to the Lattice platform hence the errors about being unable to connect). Here are some gists:
- Before: https://gist.github.com/sendhil/a33e4ffe56bda981fb06e0f3868a22e0
- After: https://gist.github.com/sendhil/8f2cf01e1e883247b8737d18aa1836d1

